### PR TITLE
    Don't crash if an entity cannot be set up.

### DIFF
--- a/custom_components/lightwave2/binary_sensor.py
+++ b/custom_components/lightwave2/binary_sensor.py
@@ -45,16 +45,24 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     #    for description in SENSORS:
     #        if featureset.has_feature(description.key):
     #            sensors.append(LWRF2BinarySensor(featureset.name, featureset_id, link, description, hass, homekit))
+    
 
     for featureset_id, name in link.get_windowsensors():
-        sensors.append(LWRF2BinarySensor(name, featureset_id, link, hass, homekit))
+        try:
+            sensors.append(LWRF2BinarySensor(name, featureset_id, link, hass, homekit))
+        except Exception as e: _LOGGER.exception("Could not add LWRF2BinarySensor")
+
 
     for featureset_id, name in link.get_switches():
         if link.featuresets[featureset_id].has_feature('outletInUse'):
-            sensors.append(LWRF2SocketBinarySensor(name, featureset_id, link, hass, homekit))
+            try:
+                sensors.append(LWRF2SocketBinarySensor(name, featureset_id, link, hass, homekit))
+            except Exception as e: _LOGGER.exception("Could not add LWRF2SocketBinarySensor")
 
     for featureset_id, name in link.get_motionsensors():
-        sensors.append(LWRF2MovementBinarySensor(name, featureset_id, link))
+        try:
+            sensors.append(LWRF2MovementBinarySensor(name, featureset_id, link))
+        except Exception as e: _LOGGER.exception("Could not add LWRF2MovementBinarySensor")
 
     hass.data[DOMAIN][config_entry.entry_id][LIGHTWAVE_ENTITIES].extend(sensors)
     async_add_entities(sensors)

--- a/custom_components/lightwave2/climate.py
+++ b/custom_components/lightwave2/climate.py
@@ -22,7 +22,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     link = hass.data[DOMAIN][config_entry.entry_id][LIGHTWAVE_LINK2]
 
     for featureset_id, name in link.get_climates():
-        climates.append(LWRF2Climate(name, featureset_id, link))
+        try:
+            climates.append(LWRF2Climate(name, featureset_id, link))
+        except Exception as e: _LOGGER.exception("Could not add LWRF2Climate")
+
 
     hass.data[DOMAIN][config_entry.entry_id][LIGHTWAVE_ENTITIES].extend(climates)
     async_add_entities(climates)

--- a/custom_components/lightwave2/cover.py
+++ b/custom_components/lightwave2/cover.py
@@ -20,7 +20,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     link = hass.data[DOMAIN][config_entry.entry_id][LIGHTWAVE_LINK2]
 
     for featureset_id, name in link.get_covers():
-        covers.append(LWRF2Cover(name, featureset_id, link))
+        try:
+            covers.append(LWRF2Cover(name, featureset_id, link))
+        except Exception as e: _LOGGER.exception("Could not add LWRF2Cover")
 
     hass.data[DOMAIN][config_entry.entry_id][LIGHTWAVE_ENTITIES].extend(covers)
     async_add_entities(covers)

--- a/custom_components/lightwave2/light.py
+++ b/custom_components/lightwave2/light.py
@@ -19,15 +19,22 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     homekit = config_entry.options.get(CONF_HOMEKIT, False)
     for featureset_id, name in link.get_lights():
+        try:
             lights.append(LWRF2Light(name, featureset_id, link, hass, homekit))
+        except Exception as e: _LOGGER.exception("Could not add LWRF2Light")
+
 
     for featureset_id, name in link.get_lights():
         if link.featuresets[featureset_id].has_led():
-            lights.append(LWRF2LED(name, featureset_id, link, hass))
+            try:
+                lights.append(LWRF2LED(name, featureset_id, link, hass))
+            except Exception as e: _LOGGER.exception("Could not add LWRF2LED")
 
     for featureset_id, name in link.get_hubs():
         if link.featuresets[featureset_id].has_led():
-            lights.append(LWRF2LED(name, featureset_id, link, hass))
+            try:
+                lights.append(LWRF2LED(name, featureset_id, link, hass))
+            except Exception as e: _LOGGER.exception("Could not add LWRF2LED")
 
     async def service_handle_brightness(light, call):
         _LOGGER.debug("Received service call set brightness %s", light._name)

--- a/custom_components/lightwave2/lock.py
+++ b/custom_components/lightwave2/lock.py
@@ -16,11 +16,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     for featureset_id, name in link.get_lights():
         if link.featuresets[featureset_id].has_feature('protection'):
-            locks.append(LWRF2Lock(name, featureset_id, link, hass))
+            try:
+                locks.append(LWRF2Lock(name, featureset_id, link, hass))
+            except Exception as e: _LOGGER.exception("Could not add LWRF2Lock")
 
     for featureset_id, name in link.get_switches():
         if link.featuresets[featureset_id].has_feature('protection'):
-            locks.append(LWRF2Lock(name, featureset_id, link, hass))
+            try:
+                locks.append(LWRF2Lock(name, featureset_id, link, hass))
+            except Exception as e: _LOGGER.exception("Could not add LWRF2Lock")
 
     hass.data[DOMAIN][config_entry.entry_id][LIGHTWAVE_ENTITIES].extend(locks)
     async_add_entities(locks)

--- a/custom_components/lightwave2/sensor.py
+++ b/custom_components/lightwave2/sensor.py
@@ -100,12 +100,14 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 sensors.append(LWRF2Sensor(featureset.name, featureset_id, link, description, hass))
     
     for featureset_id, hubname in link.get_hubs():
-        sensors.append(LWRF2EventSensor(hubname, featureset_id, link, SensorEntityDescription(
-        key="lastEvent",
-        device_class=DEVICE_CLASS_TIMESTAMP,
-        name="Last Event Received",
-        entity_category=EntityCategory.DIAGNOSTIC,
-    )))
+            try:
+                sensors.append(LWRF2EventSensor(hubname, featureset_id, link, SensorEntityDescription(
+                key="lastEvent",
+                device_class=DEVICE_CLASS_TIMESTAMP,
+                name="Last Event Received",
+                entity_category=EntityCategory.DIAGNOSTIC,
+            )))
+            except Exception as e: _LOGGER.exception("Could not add LWRF2EventSensor")
 
     hass.data[DOMAIN][config_entry.entry_id][LIGHTWAVE_ENTITIES].extend(sensors)
     async_add_entities(sensors)

--- a/custom_components/lightwave2/switch.py
+++ b/custom_components/lightwave2/switch.py
@@ -16,7 +16,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     homekit = config_entry.options.get(CONF_HOMEKIT, False)
     for featureset_id, name in link.get_switches():
-        switches.append(LWRF2Switch(name, featureset_id, link, hass, homekit))
+        try:
+            switches.append(LWRF2Switch(name, featureset_id, link, hass, homekit))
+        except Exception as e: _LOGGER.exception("Could not add LWRF2Switch")
 
     hass.data[DOMAIN][config_entry.entry_id][LIGHTWAVE_ENTITIES].extend(switches)
     async_add_entities(switches)


### PR DESCRIPTION
    Currently, if for any reason, we don't get the right data from the server, we completly crash
    the integration. Instead, we should ignore the entity and try the rest.
    This can happen for example if a user has multiple hubs and one of them is not connected
    to the network.

Fixes https://github.com/bigbadblunt/homeassistant-lightwave2/issues/116